### PR TITLE
Correct alacritty yaml keys for cursor colors

### DIFF
--- a/lua/shipwright/transform/contrib/alacritty.lua
+++ b/lua/shipwright/transform/contrib/alacritty.lua
@@ -50,8 +50,8 @@ colors:
     foreground: '$fg'
     background: '$bg'
   cursor:
-    foreground: '$cursor_fg'
-    background: '$cursor_bg'
+    cursor: '$cursor_fg'
+    text: '$cursor_bg'
   normal:
     black:   '$black'
     red:     '$red'


### PR DESCRIPTION
Use the correct key names for cursor colors in Alacritty's template.

Reference: https://github.com/alacritty/alacritty/blob/33db289f7fe31b5200317055899df6ec40bdfc6f/alacritty.yml#L206-L208
