### PR TITLE
Fix foot transform string substitution

### DIFF
--- a/lua/shipwright/transform/contrib/foot.lua
+++ b/lua/shipwright/transform/contrib/foot.lua
@@ -65,7 +65,7 @@ local function transform(colors)
       "foot colors table missing key: " .. key)
   end
 
-  local text = string.gsub(helpers.apply_template(base_template, colors), "#", "")
+  local text = string.gsub(helpers.apply_template(base_template, colors), "#([%a%d]+)", "%1")
   return helpers.split_newlines(text)
 end
 


### PR DESCRIPTION
[Foot](https://codeberg.org/dnkl/foot/src/branch/master/foot.ini#L67-L90) colors in the config file should not have a `#` prepended. This explains the substitution in the transform. However, I was also removing the `#` before the `# -*- conf -*-` comment.
